### PR TITLE
add helper to create json  required by mlflow cli

### DIFF
--- a/batch-endpoint-mlflow/src/create-json-data.py
+++ b/batch-endpoint-mlflow/src/create-json-data.py
@@ -1,0 +1,29 @@
+import os
+
+import numpy as np
+from torchvision import datasets
+import pandas as pd
+
+
+def main() -> None:
+  test_data = datasets.FashionMNIST(
+    root='data',
+    train=False,
+    download=True,
+  )
+
+  try:
+    os.mkdir('json_data')
+  except:
+    pass
+
+
+  for i in range(10):
+    images = np.asarray(test_data.data[(i*100):(i+1)*100]).reshape((100, 1, -1)).squeeze() / 255
+    df = pd.DataFrame(data=images)
+    filename = f'json_data/fashion_mnist_{i*100:04}_to_{(i+1)*100:04}.json'
+    print('writing file:', filename)
+    df.to_json(filename, orient='split') 
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
the data format created here allows the user to test the model using the mlflow cli like so:

```
mlflow models predict -m mlflow-pyfunc-model/ -i src/json_data/fashion_mnist_0100_to_0200.json --no-conda
```